### PR TITLE
Use callable instead of Closure

### DIFF
--- a/src/Iterator/CallbackIterator.php
+++ b/src/Iterator/CallbackIterator.php
@@ -4,7 +4,6 @@ namespace SMW\Notifications\Iterator;
 
 use IteratorIterator;
 use Iterator;
-use Closure;
 use ArrayIterator;
 use RuntimeException;
 
@@ -16,18 +15,15 @@ use RuntimeException;
  */
 class CallbackIterator extends IteratorIterator {
 
-	/**
-	 * @var Closure
-	 */
-	protected $callback;
+	private $callback;
 
 	/**
 	 * @since 1.0
 	 *
 	 * @param Iterator $iterator
-	 * @param Closure  $callback
+	 * @param callable  $callback
 	 */
-	public function __construct( $iterator, Closure $callback ) {
+	public function __construct( $iterator, callable $callback ) {
 
 		if ( is_array( $iterator ) ) {
 			$iterator = new ArrayIterator( $iterator );


### PR DESCRIPTION
No reason to dissalow non-clojures.

The name now reflects how the class does it job more than what it does.
How about MappingIterator?

This reminds me of http://stackoverflow.com/questions/6566129/php-lazy-array-mapping
(Y u no upvote! ;p)