### PR TITLE
 Replace `$cachedPropertyValuesPrefetcher` for SWM 3.1+ 

### DIFF
--- a/src/ChangeNotification/ChangeNotificationFilter.php
+++ b/src/ChangeNotification/ChangeNotificationFilter.php
@@ -263,7 +263,7 @@ class ChangeNotificationFilter {
 
 	private function doCompareNotificationsOnValuesWithOps( $property, $dataItem, $fieldChangeOp ) {
 
-		$cachedPropertyValuesPrefetcher = ApplicationFactory::getInstance()->getCachedPropertyValuesPrefetcher();
+		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
 
 		// Don't mix !!
 		// Either use the plain annotation style via [[Notifications on:: ...]] OR
@@ -273,7 +273,7 @@ class ChangeNotificationFilter {
 		//  |Notifications on=...
 		//  |Notifications to group=...
 		// }}
-		if ( ( $pv = $cachedPropertyValuesPrefetcher->getPropertyValues( $dataItem, $property ) ) !== array() ) {
+		if ( ( $pv = $propertySpecificationLookup->getSpecification( $dataItem, $property ) ) !== array() ) {
 			return $this->doCompareOnPropertyValues( $dataItem, $pv, $fieldChangeOp );
 		}
 

--- a/tests/phpunit/Unit/ChangeNotification/ChangeNotificationFilterTest.php
+++ b/tests/phpunit/Unit/ChangeNotification/ChangeNotificationFilterTest.php
@@ -19,7 +19,7 @@ use SMW\Tests\TestEnvironment;
 class ChangeNotificationFilterTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
-	private $cachedPropertyValuesPrefetcher;
+	private $propertySpecificationLookup;
 	private $testEnvironment;
 
 	protected function setUp() {
@@ -28,14 +28,14 @@ class ChangeNotificationFilterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->testEnvironment = new TestEnvironment();
 
 		$this->testEnvironment->registerObject( 'Store', $this->store );
-		$this->testEnvironment->registerObject( 'CachedPropertyValuesPrefetcher', $this->cachedPropertyValuesPrefetcher );
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 	}
 
 	protected function tearDown() {
@@ -220,8 +220,8 @@ class ChangeNotificationFilterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$this->cachedPropertyValuesPrefetcher->expects( $this->any() )
-			->method( 'getPropertyValues' )
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
 			->will( $this->returnValue( array( new DIBlob( '+' ) ) ) ); //Any value
 
 		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
@@ -293,8 +293,8 @@ class ChangeNotificationFilterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$this->cachedPropertyValuesPrefetcher->expects( $this->any() )
-			->method( 'getPropertyValues' )
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
 			->will( $this->returnValue( array( new DIBlob( 'DistinctText' ) ) ) ); //Distinct value
 
 		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
@@ -362,8 +362,8 @@ class ChangeNotificationFilterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$this->cachedPropertyValuesPrefetcher->expects( $this->any() )
-			->method( 'getPropertyValues' )
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
 			->will( $this->returnValue( array( new DIBlob( 'BAR' ) ) ) ); //Distinct value
 
 		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
@@ -461,8 +461,8 @@ class ChangeNotificationFilterTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( $dataItem ) )
 			->will( $this->returnValue( $semanticData ) );
 
-		$this->cachedPropertyValuesPrefetcher->expects( $this->any() )
-			->method( 'getPropertyValues' )
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
 			->will( $this->returnValue( array() ) );
 
 		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )


### PR DESCRIPTION
This PR is made in reference to: #27 

This PR addresses or contains:
- Replaces `$cachedPropertyValuesPrefetcher` with `$propertySpecificationLookup` form compatibility with SMW 3.1+

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #27 