### PR TITLE
Support `extension.json`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_27; ECHO=REL1_27; TYPE=coverage
-      php: 5.6
-    - env: DB=sqlite; MW=REL1_27; ECHO=REL1_27; SITELANG=ja
-      php: 5.6
-    - env: DB=sqlite; MW=REL1_31; ECHO=REL1_31; PHPUNIT=4.8.*
-      php: '7'
+    - env: DB=sqlite; MW=REL1_31; ECHO=REL1_31; PHPUNIT=6.5.*; SITELANG=ja
+      php: 7.1
+    - env: DB=sqlite; MW=REL1_31; ECHO=REL1_31; PHPUNIT=6.5.*; TYPE=coverage
+      php: 7.2
 
 install:
   - bash ./tests/travis/install-mediawiki.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Packagist download count](https://poser.pugx.org/mediawiki/semantic-notifications/d/total.png)](https://packagist.org/packages/mediawiki/semantic-notifications)
 
 Semantic Notifications (a.k.a. SNO) is a [Semantic Mediawiki][smw] extension that can inform registered users about
-changes to their structured data with help of the [Echo(Notifications)][echo] extension.
+changes to their structured data with the help of notifications send by the [Echo][echo] extension.
 
 Support for notifications on:
 
@@ -17,10 +17,10 @@ Support for notifications on:
 
 ## Requirements
 
-- PHP 5.5 or later
-- MediaWiki 1.27 or later
-- [Echo(Notifications)][echo] ...
-- [Semantic MediaWiki][smw] 2.4 or later
+- PHP 5.6 or later
+- MediaWiki 1.31 or later
+- [Echo (Notifications)][echo] ??
+- [Semantic MediaWiki][smw] 3.0 or later
 
 ## Installation
 

--- a/SemanticNotifications.php
+++ b/SemanticNotifications.php
@@ -7,15 +7,6 @@ use SMW\Notifications\HookRegistry;
  *
  * @defgroup SemanticNotifications Semantic Notifications
  */
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'This file is part of the Semantic Notifications extension, it is not a valid entry point.' );
-}
-
-if ( defined( 'SMW_NOTIFICATIONS_VERSION' ) ) {
-	// Do not initialize more than once.
-	return 1;
-}
-
 SemanticNotifications::load();
 
 /**
@@ -40,67 +31,27 @@ class SemanticNotifications {
 			'_MDAT',
 			'_REDI'
 		);
-
-		// In case extension.json is being used, the succeeding steps are
-		// expected to be handled by the ExtensionRegistry
-		self::initExtension();
-
-		$GLOBALS['wgExtensionFunctions'][] = function() {
-			self::onExtensionFunction();
-		};
 	}
 
 	/**
 	 * @since 1.0
 	 */
-	public static function initExtension() {
+	public static function initExtension( $credits = [] ) {
 
-		define( 'SMW_NOTIFICATIONS_VERSION', '1.0.0-alpha' );
+		$version = 'UNKNOWN' ;
 
-		// Register extension info
-		$GLOBALS['wgExtensionCredits']['semantic'][] = array(
-			'path'           => __FILE__,
-			'name'           => 'Semantic Notifications',
-			'author'         => array( 'James Hong Kong' ),
-			'url'            => 'https://github.com/SemanticMediaWiki/SemanticNotifications/',
-			'descriptionmsg' => 'smw-notifications-desc',
-			'version'        => SMW_NOTIFICATIONS_VERSION,
-			'license-name'   => 'GPL-2.0-or-later'
-		);
+		// See https://phabricator.wikimedia.org/T151136
+		if ( isset( $credits['version'] ) ) {
+			$version = $credits['version'];
+		}
+
+		define( 'SMW_NOTIFICATIONS_VERSION', $version );
 
 		// Register message files
 		$GLOBALS['wgMessagesDirs']['SemanticNotifications'] = __DIR__ . '/i18n';
 
-		self::onBeforeCreateEchoEvent();
-	}
-
-	/**
-	 * Register the hook before the execution of ExtensionFunction
-	 *
-	 * @since 1.0
-	 */
-	public static function onBeforeCreateEchoEvent() {
+		// Register the hook before the execution of ExtensionFunction
 		$GLOBALS['wgHooks']['BeforeCreateEchoEvent'][] = "\SMW\Notifications\EchoNotificationsManager::initNotificationsDefinitions";
-	}
-
-	/**
-	 * @since 1.0
-	 */
-	public static function doCheckRequirements() {
-
-		if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.27', 'lt' ) ) {
-			die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticNotifications/">Semantic Notifications</a> is only compatible with MediaWiki 1.27 or above. You need to upgrade MediaWiki first.' );
-		}
-
-		// There is no good way to detect whether Echo is available or not without
-		// making a class_exists, what should I say ...
-		if ( !isset( $GLOBALS['wgMessagesDirs']['Echo'] ) ) {
-			die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticNotifications/">Semantic Notifications</a> requires the Echo extension, please enable or install <a href="https://www.mediawiki.org/wiki/Extension:Echo">Echo(Notifications)</a> first.' );
-		}
-
-		if ( !defined( 'SMW_VERSION' ) ) {
-			die( '<b>Error:</b> <a href="https://github.com/SemanticMediaWiki/SemanticNotifications/">Semantic Notifications</a> requires the Semantic MediaWiki extension, please enable or install <a href="https://github.com/SemanticMediaWiki/SemanticMediaWiki/">Semantic MediaWiki</a> first.' );
-		}
 	}
 
 	/**
@@ -109,19 +60,33 @@ class SemanticNotifications {
 	public static function onExtensionFunction() {
 
 		// Check requirements after LocalSetting.php has been processed
-		self::doCheckRequirements();
+
+		if ( !defined( 'SMW_VERSION' ) ) {
+			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
+				die( "\nThe 'Semantic Notifications' extension requires the 'Semantic MediaWiki' extension to be installed and enabled.\n" );
+			} else {
+				die(
+					'<b>Error:</b> The <a href="https://github.com/SemanticMediaWiki/SemanticNotifications/">Semantic Notifications</a> extension' .
+					' requires the <a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> extension to be installed and enabled.<br />'
+				);
+			}
+		}
+
+		// There is no good way to detect whether Echo is available or not without
+		// making a class_exists, what should I say ...
+		if ( !isset( $GLOBALS['wgMessagesDirs']['Echo'] ) ) {
+			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
+				die( "\nThe 'Semantic Notifications' extension requires the 'Echo' extension to be installed and enabled.\n" );
+			} else {
+				die(
+					'<b>Error:</b> The <a href="https://github.com/SemanticMediaWiki/SemanticNotifications/">Semantic Notifications</a> extension' .
+					' requires the <a href="https://www.mediawiki.org/wiki/Extension:Echo">Echo</a> extension to be installed and enabled.<br />'
+				);
+			}
+		}
 
 		$hookRegistry = new HookRegistry();
 		$hookRegistry->register();
-	}
-
-	/**
-	 * @since 1.0
-	 *
-	 * @return string|null
-	 */
-	public static function getVersion() {
-		return SMW_NOTIFICATIONS_VERSION;
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"require": {
 		"php": ">=5.5.0",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/semantic-media-wiki": "~2.4|~3.0"
+		"mediawiki/semantic-media-wiki": "~3.0"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev",
@@ -52,6 +52,7 @@
 		"process-timeout": 0
 	},
 	"scripts":{
+		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"cs": [
 			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml --extensions=php -sp",

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,27 @@
+{
+	"name": "SemanticNotifications",
+	"version": "0.1-alpha",
+	"author": [
+		"James Hong Kong",
+		"..."
+	],
+	"url": "https://github.com/SemanticMediaWiki/SemanticNotifications/",
+	"descriptionmsg": "semantic-notifications-desc",
+	"namemsg": "semantic-notifications-name",
+	"license-name": "GPL-2.0-or-later",
+	"type": "semantic",
+	"requires": {
+		"MediaWiki": ">= 1.31"
+	},
+	"MessagesDirs": {
+		"SemanticNotifications": [
+			"i18n"
+		]
+	},
+	"callback": "SemanticNotifications::initExtension",
+	"ExtensionFunctions": [
+		"SemanticNotifications::onExtensionFunction"
+	],
+	"load_composer_autoloader":true,
+	"manifest_version": 1
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,11 +12,11 @@ if ( !is_readable( $autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/te
 	die( 'The Semantic MediaWiki test autoloader is not available' );
 }
 
-if ( !class_exists( 'SemanticNotifications' ) || ( $version = SemanticNotifications::getVersion() ) === null ) {
-	die( "\nSemantic Notifications is not available, please check your Composer or LocalSettings.\n" );
+if ( !defined( 'SMW_NOTIFICATIONS_VERSION' ) ) {
+	die( "\nSemantic Notifications is not available, please check your Composer or LocalSettings.\n\n" );
 }
 
-print sprintf( "\n%-20s%s\n", "Semantic Notifications: ", $version );
+print sprintf( "\n%-20s%s\n", "Semantic Notifications: ", SMW_NOTIFICATIONS_VERSION );
 
 $autoLoader = require $autoloaderClassPath;
 $autoLoader->addPsr4( 'SMW\\Notifications\\Tests\\', __DIR__ . '/phpunit/Unit' );

--- a/tests/phpunit/Unit/Iterators/ChildlessRecursiveIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/ChildlessRecursiveIteratorTest.php
@@ -4,6 +4,7 @@ namespace SMW\Notifications\Iterators\Tests;
 
 use SMW\Notifications\Iterators\ChildlessRecursiveIterator;
 use RecursiveIteratorIterator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Notifications\Iterators\ChildlessRecursiveIterator
@@ -15,6 +16,8 @@ use RecursiveIteratorIterator;
  * @author mwjames
  */
 class ChildlessRecursiveIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Iterators/MappingIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/MappingIteratorTest.php
@@ -4,6 +4,7 @@ namespace SMW\Notifications\Iterators\Tests;
 
 use SMW\Notifications\Iterators\MappingIterator;
 use ArrayIterator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Notifications\Iterators\MappingIterator
@@ -15,6 +16,8 @@ use ArrayIterator;
  * @author mwjames
  */
 class MappingIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -30,7 +30,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyRegistry->expects( $this->any() )
+		$propertyRegistry->expects( $this->atLeastOnce() )
 			->method( 'registerProperty' )
 			->withConsecutive(
 				[ $this->equalTo( PropertyRegistry::NOTIFICATIONS_ON ) ],

--- a/tests/travis/install-semantic-notifications.sh
+++ b/tests/travis/install-semantic-notifications.sh
@@ -77,6 +77,8 @@ function updateConfiguration {
 		echo 'require_once "$IP/extensions/Echo/Echo.php";' >> LocalSettings.php
 	fi
 
+	echo 'wfLoadExtension( "SemanticNotifications" );' >> LocalSettings.php
+
 	echo 'error_reporting(E_ALL| E_STRICT);' >> LocalSettings.php
 	echo 'ini_set("display_errors", 1);' >> LocalSettings.php
 	echo '$wgShowExceptionDetails = true;' >> LocalSettings.php


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Added supported for  `extension.json` therefore requires `wfLoadExtension( "SemanticNotifications" );` to enable the extension
- Changed min. requirements MW 1.31+, SMW 3.0+

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
